### PR TITLE
Use labeledLogger function instead of labeledLog

### DIFF
--- a/isolate/01-event-loop/examples/4-clear-interval.js
+++ b/isolate/01-event-loop/examples/4-clear-interval.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const log = labeledLog('4. clearInterval');
+const log = labeledLogger('4. clearInterval');
 
 // you can also stop a setInterval using it's id
 //  this happens by passing the id as an argument to clearTimeout


### PR DESCRIPTION
This fixes a bug in the example that prevented it from being ran.